### PR TITLE
Sensor identifier mapping, internal date time sensors

### DIFF
--- a/.idea/runConfigurations/Run_demo.xml
+++ b/.idea/runConfigurations/Run_demo.xml
@@ -1,7 +1,7 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Run demo" type="CargoCommandRunConfiguration" factoryName="Cargo Command">
     <option name="buildProfileId" value="dev" />
-    <option name="command" value="run --bin asterctl -- --demo -c monitor.json" />
+    <option name="command" value="run --bin demo -- -c monitor.json" />
     <option name="workingDirectory" value="file://$PROJECT_DIR$" />
     <envs />
     <option name="emulateTerminal" value="true" />

--- a/.idea/runConfigurations/Run_sysinfo.xml
+++ b/.idea/runConfigurations/Run_sysinfo.xml
@@ -1,7 +1,7 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Run sysinfo" type="CargoCommandRunConfiguration" factoryName="Cargo Command">
     <option name="buildProfileId" value="dev" />
-q    <option name="command" value="run --bin sysinfo -- --console --out ./cfg/sensors/sysinfo.txt" />
+    <option name="command" value="run --bin aster-sysinfo -- --console --out ./cfg/sensors/sysinfo.txt" />
     <option name="workingDirectory" value="file://$PROJECT_DIR$" />
     <envs />
     <option name="emulateTerminal" value="true" />

--- a/.idea/runConfigurations/Run_sysinfo_repeat.xml
+++ b/.idea/runConfigurations/Run_sysinfo_repeat.xml
@@ -1,7 +1,7 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Run sysinfo repeat" type="CargoCommandRunConfiguration" factoryName="Cargo Command">
     <option name="buildProfileId" value="dev" />
-    <option name="command" value="run --bin sysinfo -- --console --out ./cfg/sensors/sysinfo.txt --refresh 3" />
+    <option name="command" value="run --bin aster-sysinfo -- --console --out ./cfg/sensors/sysinfo.txt --refresh 3" />
     <option name="workingDirectory" value="file://$PROJECT_DIR$" />
     <envs />
     <option name="emulateTerminal" value="true" />

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -167,6 +167,7 @@ dependencies = [
  "log",
  "notify",
  "once_cell",
+ "regex",
  "rstest",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,6 +43,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -150,6 +159,7 @@ dependencies = [
  "ab_glyph",
  "anyhow",
  "asterctl-lcd",
+ "chrono",
  "clap",
  "env_logger",
  "image",
@@ -283,6 +293,19 @@ name = "cfg-if"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
+
+[[package]]
+name = "chrono"
+version = "0.4.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "wasm-bindgen",
+ "windows-link 0.2.0",
+]
 
 [[package]]
 name = "clap"
@@ -611,6 +634,30 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33e57f83510bb73707521ebaffa789ec8caf86f9657cad665b092b581d40e9fb"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "image"
@@ -1989,7 +2036,7 @@ dependencies = [
  "windows-collections",
  "windows-core",
  "windows-future",
- "windows-link",
+ "windows-link 0.1.3",
  "windows-numerics",
 ]
 
@@ -2010,7 +2057,7 @@ checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-link",
+ "windows-link 0.1.3",
  "windows-result",
  "windows-strings",
 ]
@@ -2022,7 +2069,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
  "windows-core",
- "windows-link",
+ "windows-link 0.1.3",
  "windows-threading",
 ]
 
@@ -2055,13 +2102,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
+name = "windows-link"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
+
+[[package]]
 name = "windows-numerics"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
  "windows-core",
- "windows-link",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -2070,7 +2123,7 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -2079,7 +2132,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -2122,7 +2175,7 @@ version = "0.53.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
  "windows_aarch64_gnullvm 0.53.0",
  "windows_aarch64_msvc 0.53.0",
  "windows_i686_gnu 0.53.0",
@@ -2139,7 +2192,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
 ]
 
 [[package]]

--- a/cfg/sensor-mapping/sysinfo-to-aoostar-filter.cfg
+++ b/cfg/sensor-mapping/sysinfo-to-aoostar-filter.cfg
@@ -1,0 +1,9 @@
+# Filter out specified sensor keys of the corresponding sensor file without the `-filter` suffix.
+#
+# Sensor filter for: aster-sysinfo
+#
+# Format: one RegEx entry per line.
+# Empty lines and lines starting with # are filtered out.
+
+# remove all temperature sensor units
+^temperature_.*#unit

--- a/cfg/sensor-mapping/sysinfo-to-aoostar.cfg
+++ b/cfg/sensor-mapping/sysinfo-to-aoostar.cfg
@@ -44,6 +44,3 @@ storage_hdd[5]['used']: storage_hdd[5]_usage_percent
 # TODO not (yet) available in aster-sysinfo
 # gpu_core:
 # motherboard_temperature:
-
-# Not yet supported
-# DATE_m_d_h_m_2:

--- a/cfg/sensor-mapping/sysinfo-to-aoostar.cfg
+++ b/cfg/sensor-mapping/sysinfo-to-aoostar.cfg
@@ -5,6 +5,7 @@
 # Key = label identifier used in panel definition
 # Value = label identifier used in sensor providers
 
+cpu_percent: cpu_usage_percent
 cpu_temperature: temperature_cpu
 memory_usage: mem_usage_percent
 memory_Temperature: temperature_memory
@@ -41,7 +42,6 @@ storage_hdd[4]['used']: storage_hdd[4]_usage_percent
 storage_hdd[5]['used']: storage_hdd[5]_usage_percent
 
 # TODO not (yet) available in aster-sysinfo
-# cpu_percent: cpu_usage_percent
 # gpu_core:
 # motherboard_temperature:
 

--- a/cfg/sensor-mapping/sysinfo-to-aoostar.cfg
+++ b/cfg/sensor-mapping/sysinfo-to-aoostar.cfg
@@ -1,0 +1,49 @@
+# Mapping sensor labels from sensor value providers to panel definition labels.
+#
+# Mapping definition for: aster-sysinfo
+#
+# Key = label identifier used in panel definition
+# Value = label identifier used in sensor providers
+
+cpu_temperature: temperature_cpu
+memory_usage: mem_usage_percent
+memory_Temperature: temperature_memory
+gpu_temperature: temperature_gpu
+
+# replace network_###_ with the desired interface: enp100s0f0np0 / enp100s0f1np1 / enp102s0 / enp103s0 etc
+net_upload_speed: network_enp100s0f1np1_upload_speed
+net_download_speed: network_enp100s0f1np1_download_speed
+net_ip_address: network_enp100s0f1np1_address0
+
+# Individual storage_ssd / hdd[x] disk info doesn't seem very useful for a NAS.
+# Usually there are different arrays / fs mounts. But that's easy to map now!
+storage_ssd[0]['temperature']: temperature_nvme_Composite_KINGSTON_OM8PGP41024Q-A0
+storage_ssd[0]['used']: storage_ssd[0]_usage_percent
+storage_ssd[1]['temperature']: temperature_nvme_Composite_Samsung_SSD_990_EVO_Plus_2TB
+storage_ssd[1]['used']: storage_ssd[1]_usage_percent
+# storage_ssd[2]['temperature']:
+storage_ssd[2]['used']: storage_ssd[2]_usage_percent
+# storage_ssd[3]['temperature']:
+storage_ssd[3]['used']: storage_ssd[3]_usage_percent
+# storage_ssd[4]['temperature']:
+storage_ssd[4]['used']: storage_ssd[4]_usage_percent
+# storage_hdd[0]['temperature']:
+storage_hdd[0]['used']: storage_hdd[0]_usage_percent
+# storage_hdd[1]['temperature']:
+storage_hdd[1]['used']: storage_hdd[1]_usage_percent
+# storage_hdd[2]['temperature']:
+storage_hdd[2]['used']: storage_hdd[2]_usage_percent
+# storage_hdd[3]['temperature']:
+storage_hdd[3]['used']: storage_hdd[3]_usage_percent
+# storage_hdd[4]['temperature']:
+storage_hdd[4]['used']: storage_hdd[4]_usage_percent
+# storage_hdd[5]['temperature']:
+storage_hdd[5]['used']: storage_hdd[5]_usage_percent
+
+# TODO not (yet) available in aster-sysinfo
+# cpu_percent: cpu_usage_percent
+# gpu_core:
+# motherboard_temperature:
+
+# Not yet supported
+# DATE_m_d_h_m_2:

--- a/crates/aster-sysinfo/src/main.rs
+++ b/crates/aster-sysinfo/src/main.rs
@@ -401,8 +401,8 @@ impl SysinfoSource {
                     //          component.label(), component.type_id(), component.id());
                 }
 
-                // TODO add unit as a separate sensor?
-                add_sensor(sensors, label, format!("{temperature:.1} °C"));
+                add_sensor(sensors, format!("{label}#unit"), "°C");
+                add_sensor(sensors, label, format!("{temperature:.1}"));
             }
         }
 

--- a/crates/asterctl/Cargo.toml
+++ b/crates/asterctl/Cargo.toml
@@ -15,6 +15,7 @@ asterctl-lcd = { path = "../asterctl-lcd", version = "0.2.0" }
 
 anyhow = "1.0.98"
 clap = { version = "4.5.42", features = ["derive"] }
+chrono = "0.4"
 image = "0.25.6"
 imageproc = { version = "0.25.0", default-features = false }
 ab_glyph = { version = "0.2.31", default-features = false, features = ["std"] }

--- a/crates/asterctl/Cargo.toml
+++ b/crates/asterctl/Cargo.toml
@@ -26,6 +26,7 @@ serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.142"
 serde_repr = "0.1.20"
 once_cell = "1.21.3"
+regex = "1.11.2"
 
 [dev-dependencies]
 rstest = "0.26"

--- a/crates/asterctl/src/cfg.rs
+++ b/crates/asterctl/src/cfg.rs
@@ -10,6 +10,7 @@ use anyhow::Context;
 use image::{Rgb, Rgba};
 use imageproc::definitions::HasWhite;
 use log::{info, warn};
+use regex::Regex;
 use serde::de::Visitor;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_repr::{Deserialize_repr, Serialize_repr};
@@ -122,6 +123,9 @@ pub struct MonitorConfig {
     /// Internal sensor label mapping
     #[serde(skip)]
     sensor_mapping: Option<HashMap<String, String>>,
+    /// Internal sensor filter
+    #[serde(skip)]
+    pub sensor_filter: Option<Vec<Regex>>,
 }
 
 impl MonitorConfig {

--- a/crates/asterctl/src/render.rs
+++ b/crates/asterctl/src/render.rs
@@ -7,7 +7,9 @@ use crate::cfg::{Panel, Sensor, SensorDirection, SensorMode, TextAlign};
 use crate::font::FontHandler;
 use crate::format_value;
 use crate::img::{ImageCache, Size, rotate_image};
+use crate::sensors::get_date_time_value;
 use ab_glyph::Font;
+use chrono::{DateTime, Local};
 use image::{ImageBuffer, Rgba, RgbaImage};
 use imageproc::drawing::{draw_text_mut, text_size};
 use log::{debug, error};
@@ -160,6 +162,8 @@ impl PanelRenderer {
         values: &HashMap<String, String>,
         mut background: RgbaImage,
     ) -> Result<RgbaImage, ImageProcessingError> {
+        let now: DateTime<Local> = Local::now();
+
         for sensor in &panel.sensor {
             let value = values.get(&sensor.label).cloned();
             let unit = values
@@ -169,6 +173,8 @@ impl PanelRenderer {
                 .unwrap_or_default();
 
             if let Some(value) = value {
+                self.render_sensor(&mut background, sensor, &value, &unit)?;
+            } else if let Some(value) = get_date_time_value(&sensor.label, &now) {
                 self.render_sensor(&mut background, sensor, &value, &unit)?;
             }
         }

--- a/crates/asterctl/src/sensors.rs
+++ b/crates/asterctl/src/sensors.rs
@@ -80,7 +80,7 @@ pub fn start_file_slurper<P: Into<PathBuf>>(
                         debug!("Modified sensor file ({kind:?}): {path:?}");
                         let mut val = file_values.write().expect("Poisoned sensor RwLock");
 
-                        if let Err(e) = read_from_file(path, val.deref_mut()) {
+                        if let Err(e) = read_key_value_file(path, val.deref_mut()) {
                             warn!("Failed to read sensor file {path:?}: {e}");
                             continue;
                         }
@@ -113,7 +113,7 @@ fn read_path<P: AsRef<Path>>(path: P, values: &mut HashMap<String, String>) -> a
     }
 
     if path.is_file() {
-        return read_from_file(path, values);
+        return read_key_value_file(path, values);
     }
 
     for entry in fs::read_dir(path)? {
@@ -121,7 +121,7 @@ fn read_path<P: AsRef<Path>>(path: P, values: &mut HashMap<String, String>) -> a
 
         if path.is_file()
             && path.extension().unwrap_or_default() == "txt"
-            && let Err(e) = read_from_file(&path, values)
+            && let Err(e) = read_key_value_file(&path, values)
         {
             warn!("Failed to read sensor file {path:?}: {e}");
         }
@@ -139,11 +139,11 @@ fn read_path<P: AsRef<Path>>(path: P, values: &mut HashMap<String, String>) -> a
 ///
 /// # Arguments
 ///
-/// * `path`: file path to read
-/// * `values`: HashMap to store read key-value pairs.
+/// * `path`: file path to read.
+/// * `values`: HashMap to insert key-value pairs from the file.
 ///
 /// returns: Result<(), Error>
-fn read_from_file<P: AsRef<Path>>(
+pub fn read_key_value_file<P: AsRef<Path>>(
     path: P,
     values: &mut HashMap<String, String>,
 ) -> anyhow::Result<()> {

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -19,6 +19,7 @@
         - [Progress Sensor](sensor/cfg/mode3_progress.md)
         - [Pointer Sensor](sensor/cfg/mode4_pointer.md)
 - [Sensor Value Provider](sensor/provider/README.md)
+    - [Internal Date Time](sensor/provider/internal_date_time.md)
     - [Text File Data Source](sensor/provider/text_file.md)
     - [Shell Scripts](sensor/provider/shell_scripts.md)
     - [aster-sysinfo Tool](sensor/provider/sysinfo.md)

--- a/docs/asterctl.md
+++ b/docs/asterctl.md
@@ -53,6 +53,13 @@ Options:
           Single sensor value input file or directory for multiple sensor input files.
           Default: `./cfg/sensors`
 
+      --sensor-mapping <SENSOR_MAPPING>
+          Sensor identifier mapping file. Ignored if the file does not exist.
+          
+          The configuration file will be loaded from the `config_dir` directory if no full path is specified.
+          
+          [default: sensor-mapping.cfg]
+
   -o, --off-after <OFF_AFTER>
           Switch off display n seconds after loading image or running demo
 

--- a/docs/sensor/README.md
+++ b/docs/sensor/README.md
@@ -15,10 +15,12 @@ Different sensor modes are supported:
 
 ## Sensor Data Sources
 
-The sensor value reading is separated from the `asterctl` tool.
+The sensor value reading is separated from the `asterctl` tool, with the exception of some internal sensors:
+
+- Internal [date time sensors](provider/internal_date_time.md)
 
 Sensor values are provided in separate text files and are automatically read when the file changes.  
-Only the file data source is supported at the moment, other sources like pipes, sockets etc. might be supported later.
+Only the file data source is supported at the moment; other sources like pipes, sockets, etc. might be supported later.
 
 - [Text file data source](provider/text_file.md)
 

--- a/docs/sensor/README.md
+++ b/docs/sensor/README.md
@@ -26,3 +26,28 @@ Only the file data source is supported at the moment, other sources like pipes, 
 
 - Proof of concept [Linux shell scripts](provider/shell_scripts.md)
 - [aster-sysinfo tool](provider/sysinfo.md)
+
+### Sensor Identifier Mapping
+
+The original AOOSTAR-X software uses very weird label identifiers (actually sometimes even a composite key depending on
+the data source), which are likely based on an internal JSON structure.
+
+To easily use original custom sensor panels with various sensor data sources, a sensor identifier mapping file can be used.
+
+The mapping file is a simple text file with one identifier mapping per line:
+- Key = label identifier used in panel definition
+- Value = label identifier used in sensor providers
+
+Example:
+
+```
+cpu_temperature: temperature_cpu
+```
+
+This maps the `temperature_cpu` sensor from the `aster-sysinfo` tool to the `cpu_temperature` sensor used in the
+AOOSTAR-X panel definitions.
+
+Usage example:
+```shell
+asterctl --config monitor.json --sensor-mapping sensor-mapping/sysinfo-to-aoostar.cfg
+```

--- a/docs/sensor/README.md
+++ b/docs/sensor/README.md
@@ -53,3 +53,24 @@ Usage example:
 ```shell
 asterctl --config monitor.json --sensor-mapping sensor-mapping/sysinfo-to-aoostar.cfg
 ```
+
+### Sensor Filter
+
+Sensor entries in the text file can be filtered by regular expressions defined in the sensor filter file having the
+same name as the sensor identifier mapping file, but with the `-filter` suffix in the file name.
+
+Example:
+- Sensor identifier mapping file: `sensor-mapping/sysinfo-to-aoostar.cfg`
+- Sensor filter file: `sensor-mapping/sysinfo-to-aoostar-filter.cfg`
+
+The filter file is a simple text file with one regular expression per line:
+
+Example:
+
+```
+# remove all temperature sensor units
+temperature_.*#unit
+```
+
+This removes all sensors starting with `temperature_` and ending with `#unit`, which will make sure that all the
+temperature sensors will be rendered without the unit text suffix on the display panel.

--- a/docs/sensor/provider/README.md
+++ b/docs/sensor/provider/README.md
@@ -1,1 +1,6 @@
 # Sensor Value Provider
+
+- Internal [date time sensors](internal_date_time.md)
+- Proof of concept [Linux shell scripts](shell_scripts.md)
+- [aster-sysinfo tool](sysinfo.md)
+

--- a/docs/sensor/provider/internal_date_time.md
+++ b/docs/sensor/provider/internal_date_time.md
@@ -1,0 +1,34 @@
+# Internal Date Time Sensors
+
+## Individual Components
+
+- `DATE_year`: `{year}`
+- `DATE_month`: `{month}` with leading zero
+- `DATE_day`: `{day}` with leading zero
+- `DATE_hour`: `{hour}` 24h format with leading zero
+- `DATE_minute`: `{minute}` with leading zero
+- `DATE_second`: `{second}` with leading zero
+
+## Month/Day with Hour/Minute
+- `DATE_m_d_h_m_1`: `{month}月{day}日  {hour}:{minute}`
+- `DATE_m_d_h_m_2`: `{month}/{day}  {hour}:{minute}`
+
+## Month/Day Only
+- `DATE_m_d_1`: `{month}月{day}日`
+- `DATE_m_d_2`: `{month}-{day}`
+
+## Year/Month/Day
+- `DATE_y_m_d_1`: `{year}年{month}月{day}日`
+- `DATE_y_m_d_2`: `{year}-{month}-{day}`
+- `DATE_y_m_d_3`: `{year}/{month}/{day}`
+- `DATE_y_m_d_4`: `{year} {month} {day}`
+
+## Hour/Minute/Second
+- `DATE_h_m_s_1`: `{hour}:{minute}:{second}`
+- `DATE_h_m_s_2`: `{hour}时{minute}分{second}秒`
+- `DATE_h_m_s_3`: `{hour} {minute} {second}`
+
+## Hour/Minute Only
+- `DATE_h_m_1`: `{hour}时{minute}分`
+- `DATE_h_m_2`: `{hour} : {minute}`
+- `DATE_h_m_3`: `{hour}:{minute}`


### PR DESCRIPTION
- Add sensor identifier mapping with a mapping file:
  The mapping file is a simple text file with one identifier mapping per line:
  - Key = label identifier used in panel definition
  - Value = label identifier used in sensor providers
  - Example: `cpu_temperature: temperature_cpu`
  - Closes #18
- Add sensor filter option:
  - Filter out sensors based on regex matches.
  - This allows removing all unit text suffixes if, for example, the panel image already contains the unit text as the default system panels in AOOSTAR-X.
- Add new sensors to `aster-sysinfo`:
  - `cpu_usage_percent` overall cpu usage
  - `system_uptime_sec` system uptime in seconds
  - `system_update` contains the friendly representation, similar to the uptime command in Linux.
- Support AOOSTAR-X date time sensors:
  - `DATE_year`: `{year}`
  - `DATE_month`: `{month}` with leading zero
  - `DATE_day`: `{day}` with leading zero
  - `DATE_hour`: `{hour}` 24h format with leading zero
  - `DATE_minute`: `{minute}` with leading zero
  - `DATE_second`: `{second}` with leading zero
  - `DATE_m_d_h_m_1`: `{month}月{day}日  {hour}:{minute}`
  - `DATE_m_d_h_m_2`: `{month}/{day}  {hour}:{minute}`
  - `DATE_m_d_1`: `{month}月{day}日`
  - `DATE_m_d_2`: `{month}-{day}`
  - `DATE_y_m_d_1`: `{year}年{month}月{day}日`
  - `DATE_y_m_d_2`: `{year}-{month}-{day}`
  - `DATE_y_m_d_3`: `{year}/{month}/{day}`
  - `DATE_y_m_d_4`: `{year} {month} {day}`
  - `DATE_h_m_s_1`: `{hour}:{minute}:{second}`
  - `DATE_h_m_s_2`: `{hour}时{minute}分{second}秒`
  - `DATE_h_m_s_3`: `{hour} {minute} {second}`
  - `DATE_h_m_1`: `{hour}时{minute}分`
  - `DATE_h_m_2`: `{hour} : {minute}`
  - `DATE_h_m_3`: `{hour}:{minute}`
